### PR TITLE
Output as Nix expression

### DIFF
--- a/src/nix_prefetch_github/templates/nix-output.j2
+++ b/src/nix_prefetch_github/templates/nix-output.j2
@@ -1,0 +1,9 @@
+let
+  pkgs = import <nixpkgs> {};
+in
+  pkgs.fetchFromGitHub {
+    owner = "{{ owner }}";
+    repo = "{{ repo }}";
+    rev = "{{ rev }}";
+    sha256 = "{{ sha256 }}";
+  };

--- a/src/nix_prefetch_github/templates/nix-output.j2
+++ b/src/nix_prefetch_github/templates/nix-output.j2
@@ -6,4 +6,4 @@ in
     repo = "{{ repo }}";
     rev = "{{ rev }}";
     sha256 = "{{ sha256 }}";
-  };
+  }


### PR DESCRIPTION
In short,

```
$ nix-prefetch-github --nix seppeljordan nix-prefetch-github
let
  pkgs = import <nixpkgs> {};
in
  pkgs.fetchFromGitHub {
    owner = "seppeljordan";
    repo = "nix-prefetch-github";
    rev = "f71616bde96da27329e4a6db4a339381472f2e36";
    sha256 = "1vf5i3s9ql9cr37smbqyqdrpiympjxx3kmwn6xv9h2fn5jyiwh8y";
  };
```

Also, I've tried to make `--hash-only` and `--nix` mutually exclusive, but I couldn't find an easy way to achieve it.

I.e. [this](https://stackoverflow.com/questions/37310718/mutually-exclusive-option-groups-in-python-click) method does not work properly with flags defined using slash (`--hash-only/--no-hash-only` in this case). It makes `--nix` and `--no-hash-only` mutually exclusive too.

May I ask what was the motivation for adding `--no-hash-only` flag?