### PR TITLE
Fetch submodules

### DIFF
--- a/src/nix_prefetch_github/__init__.py
+++ b/src/nix_prefetch_github/__init__.py
@@ -139,7 +139,7 @@ def detect_actual_hash_from_nix_output(lines):
 
 
 @do
-def prefetch_github(owner, repo, prefetch=True, rev=None):
+def prefetch_github(owner, repo, prefetch=True, rev=None, fetch_submodules=False):
     if isinstance(rev, str) and is_sha1_hash(rev):
         actual_rev = rev
     else:

--- a/src/nix_prefetch_github/__init__.py
+++ b/src/nix_prefetch_github/__init__.py
@@ -3,7 +3,6 @@ import os
 import re
 from tempfile import TemporaryDirectory
 
-import attr
 import click
 import jinja2
 from attr import attrib, attrs

--- a/src/nix_prefetch_github/__init__.py
+++ b/src/nix_prefetch_github/__init__.py
@@ -50,7 +50,7 @@ def to_nix_expression(output_dictionary):
         repo=output_dictionary["repo"],
         rev=output_dictionary["rev"],
         sha256=output_dictionary["sha256"],
-        fetch_submodules="true" if output_dictionary["fetch_submodules"] else "false",
+        fetch_submodules="true" if output_dictionary["fetchSubmodules"] else "false",
     )
 
 

--- a/src/nix_prefetch_github/__init__.py
+++ b/src/nix_prefetch_github/__init__.py
@@ -78,6 +78,7 @@ class CalculateSha256Sum:
     owner = attrib()
     repo = attrib()
     revision = attrib()
+    fetch_submodules = attrib(default=False)
 
 
 @do

--- a/src/nix_prefetch_github/templates/nix-output.j2
+++ b/src/nix_prefetch_github/templates/nix-output.j2
@@ -6,4 +6,5 @@ in
     repo = "{{ repo }}";
     rev = "{{ rev }}";
     sha256 = "{{ sha256 }}";
+    fetchSubmodules = {{ fetch_submodules }};
   }

--- a/src/nix_prefetch_github/templates/prefetch-github.nix.j2
+++ b/src/nix_prefetch_github/templates/prefetch-github.nix.j2
@@ -5,6 +5,7 @@ let
     repo = "{{ repo }}";
     rev = "{{ rev }}";
     sha256 = "{{ sha256 }}";
+    fetchSubmodules = {{ fetch_submodules }};
   };
 in
   import "${src}/overrides.nix" { inherit pkgs; python = pkgs.python3; }

--- a/tests/markers.py
+++ b/tests/markers.py
@@ -1,0 +1,3 @@
+import pytest
+
+requires_nix_build = pytest.mark.requires_nix_build

--- a/tests/test_calculate_sha256_sum.py
+++ b/tests/test_calculate_sha256_sum.py
@@ -1,0 +1,42 @@
+"""This module provides tests for the implementation of the
+CalculateSha256Sum intent"""
+from functools import wraps
+
+from effect import Effect, sync_perform
+
+from nix_prefetch_github import CalculateSha256Sum, dispatcher
+
+from .markers import requires_nix_build
+
+
+def performer_test(f):
+    @wraps(f)
+    def _wrapped(*args, **kwargs):
+        generator = f(*args, **kwargs)
+        intent = generator.send(None)
+        while True:
+            intent_result = sync_perform(dispatcher(), Effect(intent))
+            try:
+                intent = generator.send(intent_result)
+            except StopIteration:
+                return
+
+    return _wrapped
+
+
+@requires_nix_build
+@performer_test
+def test_fetch_submodules_gives_different_hash_than_without_fetching_submodules():
+    hash_without_submodules = yield CalculateSha256Sum(
+        owner="hasktorch",
+        repo="hasktorch",
+        revision="db5962b75d4b8790759692a3e080facb4084ba01",
+        fetch_submodules=False,
+    )
+    hash_with_submodules = yield CalculateSha256Sum(
+        owner="hasktorch",
+        repo="hasktorch",
+        revision="db5962b75d4b8790759692a3e080facb4084ba01",
+        fetch_submodules=True,
+    )
+    assert hash_with_submodules != hash_without_submodules

--- a/tests/test_prefetch_github.py
+++ b/tests/test_prefetch_github.py
@@ -169,7 +169,11 @@ def test_is_sha1_hash_returns_false_for_string_to_short():
 def test_is_to_nix_expression_outputs_valid_nix_expr():
     for prefetch in [False, True]:
         output_dictionary = nix_prefetch_github.nix_prefetch_github(
-            owner="seppeljordan", repo="pypi2nix", prefetch=prefetch, rev="master"
+            owner="seppeljordan",
+            repo="pypi2nix",
+            prefetch=prefetch,
+            rev="master",
+            fetch_submodules=False,
         )
         nix_expr_output = nix_prefetch_github.to_nix_expression(output_dictionary)
 

--- a/tests/test_prefetch_github.py
+++ b/tests/test_prefetch_github.py
@@ -11,7 +11,7 @@ from nix_prefetch_github.error import (
 from nix_prefetch_github.io import cmd
 from nix_prefetch_github.list_remote import ListRemote
 
-requires_nix_build = pytest.mark.requires_nix_build
+from .markers import requires_nix_build
 
 
 @pytest.fixture
@@ -244,12 +244,12 @@ def test_that_prefetch_github_understands_fetch_submodules(pypi2nix_list_remote)
                 owner="seppeljordan",
                 repo="pypi2nix",
                 revision=pypi2nix_list_remote.branch("master"),
-                fetch_submodules=False,
+                fetch_submodules=True,
             ),
             lambda i: "TEST_ACTUALHASH",
         ),
     ]
     effect = nix_prefetch_github.prefetch_github(
-        owner="seppeljordan", repo="pypi2nix", prefetch=False, fetch_submodules=False
+        owner="seppeljordan", repo="pypi2nix", prefetch=False, fetch_submodules=True
     )
     prefetch_result = perform_sequence(sequence, effect)

--- a/tests/test_prefetch_github.py
+++ b/tests/test_prefetch_github.py
@@ -244,6 +244,7 @@ def test_that_prefetch_github_understands_fetch_submodules(pypi2nix_list_remote)
                 owner="seppeljordan",
                 repo="pypi2nix",
                 revision=pypi2nix_list_remote.branch("master"),
+                fetch_submodules=False,
             ),
             lambda i: "TEST_ACTUALHASH",
         ),

--- a/tests/test_prefetch_github.py
+++ b/tests/test_prefetch_github.py
@@ -252,4 +252,4 @@ def test_that_prefetch_github_understands_fetch_submodules(pypi2nix_list_remote)
     effect = nix_prefetch_github.prefetch_github(
         owner="seppeljordan", repo="pypi2nix", prefetch=False, fetch_submodules=True
     )
-    prefetch_result = perform_sequence(sequence, effect)
+    perform_sequence(sequence, effect)

--- a/tests/test_prefetch_github.py
+++ b/tests/test_prefetch_github.py
@@ -231,3 +231,24 @@ def test_that_prefetch_github_understands_full_ref_names(pypi2nix_list_remote):
     prefetch_result = perform_sequence(sequence, effect)
     assert prefetch_result["rev"] == pypi2nix_list_remote.branch("master")
     assert prefetch_result["sha256"] == "TEST_ACTUALHASH"
+
+
+def test_that_prefetch_github_understands_fetch_submodules(pypi2nix_list_remote):
+    sequence = [
+        (
+            nix_prefetch_github.GetListRemote(owner="seppeljordan", repo="pypi2nix"),
+            lambda i: pypi2nix_list_remote,
+        ),
+        (
+            nix_prefetch_github.CalculateSha256Sum(
+                owner="seppeljordan",
+                repo="pypi2nix",
+                revision=pypi2nix_list_remote.branch("master"),
+            ),
+            lambda i: "TEST_ACTUALHASH",
+        ),
+    ]
+    effect = nix_prefetch_github.prefetch_github(
+        owner="seppeljordan", repo="pypi2nix", prefetch=False, fetch_submodules=False
+    )
+    prefetch_result = perform_sequence(sequence, effect)


### PR DESCRIPTION
Closes #30 

A new flag `--fetch-submodules` allows the user to also fetch any submodules contained in the git repository.