### PR TITLE
Don't include fetchSubmodules if it's false in nix template

### DIFF
--- a/nix_prefetch_github/templates.py
+++ b/nix_prefetch_github/templates.py
@@ -5,8 +5,7 @@ in
     owner = "{owner}";
     repo = "{repo}";
     rev = "{rev}";
-    sha256 = "{sha256}";
-    fetchSubmodules = {fetch_submodules};
+    sha256 = "{sha256}";{fetch_submodules}
   }}
 """
 
@@ -19,5 +18,5 @@ def output_template(
         repo=repo,
         rev=rev,
         sha256=sha256,
-        fetch_submodules="true" if fetch_submodules else "false",
+        fetch_submodules="\n    fetchSubmodules = true;" if fetch_submodules else "",
     )


### PR DESCRIPTION
The default is false and it doesn't make sense to include it,
it just clobbers up the derivation