### PR TITLE
fix: bake git into PATH at runtime

### DIFF
--- a/nix/nix-prefetch-github.nix
+++ b/nix/nix-prefetch-github.nix
@@ -7,6 +7,11 @@ in buildPythonPackage {
   outputs = [ "out" "doc" "man" ];
   src = ../.;
   nativeBuildInputs = [ sphinxHook sphinx-argparse ];
+  postInstall = ''
+    for f in $out/bin/* ; do
+        wrapProgram "$f" --prefix PATH : "${git}/bin"
+    done
+  '';
   checkInputs = [ git which pytestCheckHook ];
   sphinxBuilders = [ "singlehtml" "man" ];
   sphinxRoot = "docs";


### PR DESCRIPTION
This way you can run nixpkgs on a fresh nixos install with flakes enabled but without git globally installed.

Demo:

```
$ nix run github:seppeljordan/nix-prefetch-github -- hraban opus
Traceback (most recent call last):
  File "/nix/store/83nszrlr1dj1lbnjyry24ji3drf90ik0-python3.10-nix-prefetch-github-5.2.2-dev/bin/.nix-prefetch-github-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/83nszrlr1dj1lbnjyry24ji3drf90ik0-python3.10-nix-prefetch-github-5.2.2-dev/lib/python3.10/site-packages/nix_prefetch_github/cli/fetch_github.py", line 9, in main
    controller.process_arguments(sys.argv[1:])
  File "/nix/store/83nszrlr1dj1lbnjyry24ji3drf90ik0-python3.10-nix-prefetch-github-5.2.2-dev/lib/python3.10/site-packages/nix_prefetch_github/controller/nix_prefetch_github_controller.py", line 29, in process_arguments
    self._use_case.prefetch_github_repository(
  File "/nix/store/83nszrlr1dj1lbnjyry24ji3drf90ik0-python3.10-nix-prefetch-github-5.2.2-dev/lib/python3.10/site-packages/nix_prefetch_github/use_cases/prefetch_github_repository.py", line 38, in prefetch_github_repository
    prefetch_result = self.prefetcher.prefetch_github(
  File "/nix/store/83nszrlr1dj1lbnjyry24ji3drf90ik0-python3.10-nix-prefetch-github-5.2.2-dev/lib/python3.10/site-packages/nix_prefetch_github/prefetch.py", line 33, in prefetch_github
    revision = self._detect_revision(repository, rev)
  File "/nix/store/83nszrlr1dj1lbnjyry24ji3drf90ik0-python3.10-nix-prefetch-github-5.2.2-dev/lib/python3.10/site-packages/nix_prefetch_github/prefetch.py", line 67, in _detect_revision
    revision_index = self.revision_index_factory.get_revision_index(repository)
  File "/nix/store/83nszrlr1dj1lbnjyry24ji3drf90ik0-python3.10-nix-prefetch-github-5.2.2-dev/lib/python3.10/site-packages/nix_prefetch_github/revision_index_factory.py", line 23, in get_revision_index
    RevisionIndexImpl, self.list_remote_factory.get_list_remote(repository)
  File "/nix/store/83nszrlr1dj1lbnjyry24ji3drf90ik0-python3.10-nix-prefetch-github-5.2.2-dev/lib/python3.10/site-packages/nix_prefetch_github/list_remote_factory.py", line 14, in get_list_remote
    returncode, output = self.command_runner.run_command(
  File "/nix/store/83nszrlr1dj1lbnjyry24ji3drf90ik0-python3.10-nix-prefetch-github-5.2.2-dev/lib/python3.10/site-packages/nix_prefetch_github/command/command_runner.py", line 25, in run_command
    process = subprocess.Popen(
  File "/nix/store/zdba9frlxj2ba8ca095win3nphsiiqhb-python3-3.10.8/lib/python3.10/subprocess.py", line 971, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/nix/store/zdba9frlxj2ba8ca095win3nphsiiqhb-python3-3.10.8/lib/python3.10/subprocess.py", line 1847, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'git'

$ nix run github:hraban/nix-prefetch-github/fix/git-path -- hraban opus
{
    "owner": "hraban",
    "repo": "opus",
    "rev": "eeacdbcb92d065418ad40f65e8a30e0d0a88885d",
    "sha256": "ljRop2Nlt0Ip+sYaQutiMOP8Sl05iKdGQdqcIuA6FpU="
}
```