### PR TITLE
Fixes for integration tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,7 +10,7 @@ jobs:
   build-nix:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.3.0
     - uses: cachix/install-nix-action@v20
       with:
         nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -2,9 +2,6 @@ name: nix-prefetch-github tests
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   build-nix:

--- a/nix_prefetch_github/dependency_injector.py
+++ b/nix_prefetch_github/dependency_injector.py
@@ -111,7 +111,9 @@ class DependencyInjector:
         return GithubAPIImpl(logger=self.get_logger())
 
     def get_repository_detector(self) -> RepositoryDetector:
-        return RepositoryDetectorImpl(command_runner=self.get_command_runner())
+        return RepositoryDetectorImpl(
+            command_runner=self.get_command_runner(), logger=self.get_logger()
+        )
 
     def get_command_runner(self) -> CommandRunnerImpl:
         return CommandRunnerImpl(logger=self.get_logger())

--- a/nix_prefetch_github/repository_detector.py
+++ b/nix_prefetch_github/repository_detector.py
@@ -42,12 +42,15 @@ class RepositoryDetectorImpl:
 
 
 def detect_github_repository_from_remote_url(url: str) -> Optional[GithubRepository]:
-    match = re.match("(git@github.com:|https://github.com/)(.+)/(.+).git", url)
+    match = re.match(
+        r"(git@github.com:|https://github.com/)(?P<owner>.+)/((?P<repo>.+)\.git|(?P<repo_with_prefix>.+))$",
+        url,
+    )
     if not match:
         return None
     else:
-        owner = match.group(2)
-        name = match.group(3)
+        owner = match.group("owner")
+        name = match.group("repo") or match.group("repo_with_prefix")
         return GithubRepository(
             name=name,
             owner=owner,

--- a/nix_prefetch_github/repository_detector.py
+++ b/nix_prefetch_github/repository_detector.py
@@ -1,5 +1,6 @@
 import re
 from dataclasses import dataclass
+from logging import Logger
 from typing import Optional
 
 from nix_prefetch_github.interfaces import CommandRunner, GithubRepository
@@ -8,6 +9,7 @@ from nix_prefetch_github.interfaces import CommandRunner, GithubRepository
 @dataclass
 class RepositoryDetectorImpl:
     command_runner: CommandRunner
+    logger: Logger
 
     def is_repository_dirty(self, directory: str) -> bool:
         returncode, _ = self.command_runner.run_command(
@@ -26,7 +28,9 @@ class RepositoryDetectorImpl:
         returncode, stdout = self.command_runner.run_command(
             command=["git", "remote", "get-url", remote], cwd=directory
         )
-        return detect_github_repository_from_remote_url(stdout)
+        detected_url = detect_github_repository_from_remote_url(stdout)
+        self.logger.info(f"Detected repository '{detected_url}' from '{remote}'")
+        return detected_url
 
     def get_current_revision(self, directory: str) -> Optional[str]:
         exitcode, stdout = self.command_runner.run_command(

--- a/nix_prefetch_github/test_repository_detector.py
+++ b/nix_prefetch_github/test_repository_detector.py
@@ -106,6 +106,13 @@ class DetectGithubRepositoryFromRemoteUrlTests(TestCase):
                 ),
             ),
             (
+                "https://github.com/seppeljordan/nix-prefetch-github",
+                GithubRepository(
+                    owner="seppeljordan",
+                    name="nix-prefetch-github",
+                ),
+            ),
+            (
                 "invalid",
                 None,
             ),

--- a/nix_prefetch_github/test_repository_detector.py
+++ b/nix_prefetch_github/test_repository_detector.py
@@ -2,6 +2,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+from io import StringIO
 from logging import getLogger
 from unittest import TestCase
 
@@ -19,7 +20,11 @@ class GitTestCase(TestCase):
         self.run_command("git init")
         self.run_command("git config user.name 'test user'")
         self.run_command("git config user.email test@email.test")
-        self.detector = RepositoryDetectorImpl(CommandRunnerImpl(getLogger(__name__)))
+        self.stream = StringIO()
+        self.logger = getLogger(__name__)
+        self.detector = RepositoryDetectorImpl(
+            command_runner=CommandRunnerImpl(logger=self.logger), logger=self.logger
+        )
 
     def tearDown(self) -> None:
         shutil.rmtree(self.tmpdir)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -142,9 +142,22 @@ class JsonIntegrityTests(TestCase):
             ],
         ]
         for expression in expressions:
-            with self.subTest(msg=shlex.join(expression)):
-                finished_process = subprocess.run(expression, capture_output=True)
-                self.assertEqual(finished_process.returncode, 0)
+            expression_shell_command = shlex.join(expression)
+            with self.subTest(msg=expression_shell_command):
+                finished_process = subprocess.run(
+                    expression, capture_output=True, universal_newlines=True
+                )
+                self.assertEqual(
+                    finished_process.returncode,
+                    0,
+                    msg="\n".join(
+                        [
+                            f"Failed to execute {expression_shell_command}.",
+                            f"stdout: {finished_process.stdout}",
+                            f"stderr: {finished_process.stderr}",
+                        ]
+                    ),
+                )
                 json.loads(finished_process.stdout)
 
     def test_can_use_json_output_as_input_for_fetch_from_github(self) -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -74,6 +74,9 @@ class VersionFlagTests(TestCase):
             with self.subTest(msg=command):
                 self.assertReturncode([f"{self.output}/bin/{command}", "--version"], 0)
 
+    def tearDown(self) -> None:
+        shutil.rmtree(self.directory)
+
 
 @network
 @requires_nix_build
@@ -121,6 +124,9 @@ class JsonIntegrityTests(TestCase):
         self.directory = tempfile.mkdtemp()
         self.output = path.join(self.directory, "result")
         subprocess.run(["nix", "build", "--out-link", self.output], capture_output=True)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.directory)
 
     def test_can_load_json_output_as_json(self) -> None:
         expressions = [
@@ -182,9 +188,6 @@ class JsonIntegrityTests(TestCase):
             check=True,
             cwd=self.directory,
         )
-
-    def tearDown(self) -> None:
-        shutil.rmtree(self.directory)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There were several problems with the test pipeline (github workflows) that caused test failure. The main reason for this is that github checks out a merge request instead of HEAD when running the test pipeline on `pull_request:`. This causes `nix-prefetch-github-directory` to fail. With this change the test pipeline is triggered on `push:` instead which leads to HEAD being checked out.

In the process of fixing the integration test bug we discovered a bug in `nix-prefetch-github-directory` which prevented the detection from working if the repository url did not end in `.git`. This issue was addressed in this PR.