### PR TITLE
Implement extended output format with commit timestamp

### DIFF
--- a/README.org
+++ b/README.org
@@ -18,8 +18,8 @@
   {
       "owner": "seppeljordan",
       "repo": "nix-prefetch-github",
-      "rev": "c2da1e1a6fb379285a34ca6458f01f372e28a24e",
-      "hash": "sha256-qaDF4tsw924OQabYF2FrelStpQ6cXW9G2eD+XX9zy+8="
+      "rev": "22a1d51238702d7ca2c5c68cb0eeddbfce0f12f4",
+      "hash": "sha256-22itTJBoXyoQ76Rgh2bImQBzo3sYkOA2Zhiv2xqxDNM="
   }
   #+end_example
 
@@ -38,7 +38,8 @@
    usage: nix-prefetch-github [-h] [--fetch-submodules] [--no-fetch-submodules]
 			      [--leave-dot-git] [--no-leave-dot-git]
 			      [--deep-clone] [--no-deep-clone] [--verbose]
-			      [--quiet] [--nix] [--json] [--version] [--rev REV]
+			      [--quiet] [--nix] [--json] [--meta] [--version]
+			      [--rev REV]
 			      owner repo
 
    positional arguments:
@@ -64,6 +65,11 @@
      --quiet, -q           Print less information about the programs execution.
      --nix                 Output the results as valid nix code.
      --json                Output the results in the JSON format
+     --meta                Output the results in JSON format where the arguments
+			   to fetchFromGitHub are located under the src key of
+			   the resulting json dictionary and meta information
+			   about the prefetched repository is located under the
+			   meta key of the output.
      --version             show program's version number and exit
      --rev REV
    #+end_example
@@ -87,7 +93,7 @@
 						 [--no-leave-dot-git]
 						 [--deep-clone] [--no-deep-clone]
 						 [--verbose] [--quiet] [--nix]
-						 [--json] [--version]
+						 [--json] [--meta] [--version]
 						 [--directory DIRECTORY]
 						 [--remote REMOTE]
 
@@ -110,6 +116,11 @@
      --quiet, -q           Print less information about the programs execution.
      --nix                 Output the results as valid nix code.
      --json                Output the results in the JSON format
+     --meta                Output the results in JSON format where the arguments
+			   to fetchFromGitHub are located under the src key of
+			   the resulting json dictionary and meta information
+			   about the prefetched repository is located under the
+			   meta key of the output.
      --version             show program's version number and exit
      --directory DIRECTORY
      --remote REMOTE
@@ -130,7 +141,7 @@
 					     [--leave-dot-git]
 					     [--no-leave-dot-git] [--deep-clone]
 					     [--no-deep-clone] [--verbose]
-					     [--quiet] [--nix] [--json]
+					     [--quiet] [--nix] [--json] [--meta]
 					     [--version]
 					     owner repo
 
@@ -157,6 +168,11 @@
      --quiet, -q           Print less information about the programs execution.
      --nix                 Output the results as valid nix code.
      --json                Output the results in the JSON format
+     --meta                Output the results in JSON format where the arguments
+			   to fetchFromGitHub are located under the src key of
+			   the resulting json dictionary and meta information
+			   about the prefetched repository is located under the
+			   meta key of the output.
      --version             show program's version number and exit
    #+end_example
 
@@ -186,8 +202,10 @@
   
 
 * changes
-** v7.0.1
+** v7.1.0
    - Add =-q= / =--quiet= option to decrease logging verbosity
+   - Add =--meta= option to include the commit timestamp of the latest
+     prefetched commit in the output
 
 ** v7.0.0
    - The output format changed. In previous versions the json and nix

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -19,8 +19,8 @@ Command Line Example
    {
        "owner": "seppeljordan",
        "repo": "nix-prefetch-github",
-       "rev": "c2da1e1a6fb379285a34ca6458f01f372e28a24e",
-       "hash": "sha256-qaDF4tsw924OQabYF2FrelStpQ6cXW9G2eD+XX9zy+8="
+       "rev": "22a1d51238702d7ca2c5c68cb0eeddbfce0f12f4",
+       "hash": "sha256-22itTJBoXyoQ76Rgh2bImQBzo3sYkOA2Zhiv2xqxDNM="
    }
 
 Available Commands
@@ -40,7 +40,8 @@ into the local nix store. It also prints the function arguments to
    usage: nix-prefetch-github [-h] [--fetch-submodules] [--no-fetch-submodules]
                   [--leave-dot-git] [--no-leave-dot-git]
                   [--deep-clone] [--no-deep-clone] [--verbose]
-                  [--quiet] [--nix] [--json] [--version] [--rev REV]
+                  [--quiet] [--nix] [--json] [--meta] [--version]
+                  [--rev REV]
                   owner repo
 
    positional arguments:
@@ -66,6 +67,11 @@ into the local nix store. It also prints the function arguments to
      --quiet, -q           Print less information about the programs execution.
      --nix                 Output the results as valid nix code.
      --json                Output the results in the JSON format
+     --meta                Output the results in JSON format where the arguments
+               to fetchFromGitHub are located under the src key of
+               the resulting json dictionary and meta information
+               about the prefetched repository is located under the
+               meta key of the output.
      --version             show program's version number and exit
      --rev REV
 
@@ -86,7 +92,7 @@ the ``origin`` remote repository similar to the command
                          [--no-leave-dot-git]
                          [--deep-clone] [--no-deep-clone]
                          [--verbose] [--quiet] [--nix]
-                         [--json] [--version]
+                         [--json] [--meta] [--version]
                          [--directory DIRECTORY]
                          [--remote REMOTE]
 
@@ -109,6 +115,11 @@ the ``origin`` remote repository similar to the command
      --quiet, -q           Print less information about the programs execution.
      --nix                 Output the results as valid nix code.
      --json                Output the results in the JSON format
+     --meta                Output the results in JSON format where the arguments
+               to fetchFromGitHub are located under the src key of
+               the resulting json dictionary and meta information
+               about the prefetched repository is located under the
+               meta key of the output.
      --version             show program's version number and exit
      --directory DIRECTORY
      --remote REMOTE
@@ -126,7 +137,7 @@ repository.
                          [--leave-dot-git]
                          [--no-leave-dot-git] [--deep-clone]
                          [--no-deep-clone] [--verbose]
-                         [--quiet] [--nix] [--json]
+                         [--quiet] [--nix] [--json] [--meta]
                          [--version]
                          owner repo
 
@@ -153,6 +164,11 @@ repository.
      --quiet, -q           Print less information about the programs execution.
      --nix                 Output the results as valid nix code.
      --json                Output the results in the JSON format
+     --meta                Output the results in JSON format where the arguments
+               to fetchFromGitHub are located under the src key of
+               the resulting json dictionary and meta information
+               about the prefetched repository is located under the
+               meta key of the output.
      --version             show program's version number and exit
 
 development environment
@@ -183,10 +199,12 @@ You can generate a coverage report for the tests via
 changes
 =======
 
-v7.0.1
+v7.1.0
 ------
 
 -  Add ``-q`` / ``--quiet`` option to decrease logging verbosity
+-  Add ``--meta`` option to included time commit timestamp of the latest
+   prefetched commit in the output
 
 v7.0.0
 ------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,6 +62,27 @@ nix code::
 
   src = with builtins; fetchFromGitHub (fromJSON (readFile ./nix-prefetch-github-output.json))
 
+
+Meta information output
+-----------------------
+
+The ``--meta`` argument produces output similar to the output produced
+by ``--json``. The difference is that a nested dictionary is produced
+with two top level keys: ``src`` and ``meta``. The ``src`` key will
+contain the same data as would have been yielded by ``--json`` whereas
+the ``meta`` key contains some meta data on the commit that was
+fetched. At the moment this will only be the date and time of day of
+the latest commit. This can be useful when providing nightly versions
+of a package::
+
+  let fetchedSourceCode = (fromJSON (readFile ./nix-prefetch-github-output.json));
+  in buildPackage {
+    pname = "my-package";
+    version = fetchedSourceCode.meta.commitDate;
+    src = fetchFromGitHub fetchedSourceCode.src;
+    ...
+  };
+
 Nix output
 ----------
 

--- a/nix_prefetch_github/controller/arguments.py
+++ b/nix_prefetch_github/controller/arguments.py
@@ -134,6 +134,13 @@ def get_options_argument_parser() -> argparse.ArgumentParser:
         help="Output the results in the JSON format",
     )
     parser.add_argument(
+        "--meta",
+        dest="rendering_format",
+        action="store_const",
+        const=RenderingFormat.meta,
+        help="Output the results in JSON format where the arguments to fetchFromGitHub are located under the src key of the resulting json dictionary and meta information about the prefetched repository is located under the meta key of the output.",
+    )
+    parser.add_argument(
         "--version", action="version", version="%(prog)s " + VERSION_STRING
     )
     return parser

--- a/nix_prefetch_github/dependency_injector.py
+++ b/nix_prefetch_github/dependency_injector.py
@@ -28,6 +28,7 @@ from nix_prefetch_github.prefetch import PrefetcherImpl
 from nix_prefetch_github.presenter import PresenterImpl
 from nix_prefetch_github.presenter.repository_renderer import (
     JsonRepositoryRenderer,
+    MetaRepositoryRenderer,
     NixRepositoryRenderer,
     RenderingSelectorImpl,
 )
@@ -108,11 +109,18 @@ class DependencyInjector:
     def get_json_repository_renderer(self) -> JsonRepositoryRenderer:
         return JsonRepositoryRenderer()
 
+    def get_meta_repository_renderer(self) -> MetaRepositoryRenderer:
+        return MetaRepositoryRenderer(
+            github_api=self.get_github_api(),
+            json_renderer=self.get_json_repository_renderer(),
+        )
+
     @lru_cache
     def get_rendering_format_selector(self) -> RenderingSelectorImpl:
         return RenderingSelectorImpl(
             nix_renderer=self.get_nix_repository_renderer(),
             json_renderer=self.get_json_repository_renderer(),
+            meta_renderer=self.get_meta_repository_renderer(),
         )
 
     def get_github_api(self) -> GithubAPI:

--- a/nix_prefetch_github/interfaces.py
+++ b/nix_prefetch_github/interfaces.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import enum
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Dict, List, Optional, Protocol, Tuple, Union
 
 
@@ -53,6 +54,11 @@ class UrlHasher(Protocol):
 
 class GithubAPI(Protocol):
     def get_tag_of_latest_release(self, repository: GithubRepository) -> Optional[str]:
+        ...
+
+    def get_commit_date(
+        self, repository: GithubRepository, commit_sha1_hash: str
+    ) -> Optional[datetime]:
         ...
 
 
@@ -142,6 +148,7 @@ class Presenter(Protocol):
 class RenderingFormat(enum.Enum):
     nix = enum.auto()
     json = enum.auto()
+    meta = enum.auto()
 
 
 class RenderingFormatSelector(Protocol):

--- a/nix_prefetch_github/presenter/test_rendering_selector_impl.py
+++ b/nix_prefetch_github/presenter/test_rendering_selector_impl.py
@@ -14,9 +14,11 @@ class RenderingSelectorImplTests(BaseTestCase):
         super().setUp()
         self.nix_renderer = RepositoryRendererImpl("nix format")
         self.json_renderer = RepositoryRendererImpl("json format")
+        self.meta_renderer = RepositoryRendererImpl("meta format")
         self.rendering_selector = RenderingSelectorImpl(
             nix_renderer=self.nix_renderer,
             json_renderer=self.json_renderer,
+            meta_renderer=self.meta_renderer,
         )
 
     def test_by_default_json_format_is_selectored(self) -> None:
@@ -53,6 +55,13 @@ class RenderingSelectorImplTests(BaseTestCase):
             self.get_repository()
         )
         self.assertEqual(output, "nix format 2")
+
+    def test_that_meta_renderer_is_used_when_format_is_set_to_meta(self) -> None:
+        self.rendering_selector.set_rendering_format(RenderingFormat.meta)
+        output = self.rendering_selector.render_prefetched_repository(
+            self.get_repository()
+        )
+        self.assertEqual(output, "meta format")
 
     def get_repository(self) -> PrefetchedRepository:
         return PrefetchedRepository(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -195,6 +195,32 @@ class JsonIntegrityTests(TestCase):
             cwd=self.directory,
         )
 
+    def test_can_use_json_output_as_input_when_meta_argument_is_specified(
+        self,
+    ) -> None:
+        expression = [
+            f"{self.output}/bin/nix-prefetch-github",
+            "seppeljordan",
+            "nix-prefetch-github",
+            "--meta",
+        ]
+        finished_process = subprocess.run(
+            expression, capture_output=True, check=True, universal_newlines=True
+        )
+        with open(Path(self.directory) / "output.json", "w") as handle:
+            handle.write(finished_process.stdout)
+        subprocess.run(
+            [
+                "nix",
+                "build",
+                "--impure",
+                "--expr",
+                "with import <nixpkgs> {}; with builtins; fetchFromGitHub (fromJSON (readFile ./output.json)).src",
+            ],
+            check=True,
+            cwd=self.directory,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
With this change we introduce a new commandline option `--meta` to all of our command line programs. This new option will change the output format such that the commit timestamp of the latest commit included in the prefetched github repository is included in a dedicated `meta` section of the json output.

Sample output:

```
$ nix-prefetch-github-latest-release seppeljordan nix-prefetch-github --meta
{
    "src": {
        "owner": "seppeljordan",
        "repo": "nix-prefetch-github",
        "rev": "0b35faf8532781cb0e36dcdd73273bff4eef1396",
        "hash": "sha256-oIR2iEiOBQ1VKouJTLqEiWWNzrMSJcnxK+m/j9Ia/m8="
    },
    "meta": {
        "commitDate": "2023-07-07",
        "commitTimeOfDay": "15:54:13"
    }
}
```

_fixes #59_ 