### PR TITLE
Update development dependencies

### DIFF
--- a/README.org
+++ b/README.org
@@ -18,8 +18,8 @@
   {
       "owner": "seppeljordan",
       "repo": "nix-prefetch-github",
-      "rev": "b89933bf5643c97f00c374b39af4f265eef83220",
-      "hash": "sha256-8veCTba0fhHEUPLge58FfWlk6tnYfAL852AYXWLu4Ss="
+      "rev": "244024cbbda3638e93b1a18d10e0c36f3d62e6b4",
+      "hash": "sha256-eQd/MNlnuzXzgFzvwUMchvHoIvkIrbpGKV7iknO14Cc="
   }
   #+end_example
 
@@ -202,6 +202,10 @@
   
 
 * changes
+** v8.0.0 (not released yet)
+   - Drop official support for Python versions <3.11 and introduce
+     official support for Python version 3.12
+
 ** v7.1.0
    - Add =-q= / =--quiet= option to decrease logging verbosity
    - Add =--meta= option to include the commit timestamp of the latest

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -19,8 +19,8 @@ Command Line Example
    {
        "owner": "seppeljordan",
        "repo": "nix-prefetch-github",
-       "rev": "b89933bf5643c97f00c374b39af4f265eef83220",
-       "hash": "sha256-8veCTba0fhHEUPLge58FfWlk6tnYfAL852AYXWLu4Ss="
+       "rev": "244024cbbda3638e93b1a18d10e0c36f3d62e6b4",
+       "hash": "sha256-eQd/MNlnuzXzgFzvwUMchvHoIvkIrbpGKV7iknO14Cc="
    }
 
 Available Commands
@@ -198,6 +198,12 @@ You can generate a coverage report for the tests via
 
 changes
 =======
+
+v8.0.0 (not released yet)
+-------------------------
+
+-  Drop official support for Python versions <3.11 and introduce
+   official support for Python version 3.12
 
 v7.1.0
 ------

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703637592,
-        "narHash": "sha256-8MXjxU0RfFfzl57Zy3OfXCITS0qWDNLzlBAdwxGZwfY=",
+        "lastModified": 1727802920,
+        "narHash": "sha256-HP89HZOT0ReIbI7IJZJQoJgxvB2Tn28V6XS3MNKnfLs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cfc3698c31b1fb9cdcf10f36c9643460264d0ca8",
+        "rev": "27e30d177e57d912d614c88c622dcfdb2e6e6515",
         "type": "github"
       },
       "original": {
@@ -36,16 +36,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1703992652,
-        "narHash": "sha256-C0o8AUyu8xYgJ36kOxJfXIroy9if/G6aJbNOpA5W0+M=",
+        "lastModified": 1727672256,
+        "narHash": "sha256-9/79hjQc9+xyH+QxeMcRsA6hDyw6Z9Eo1/oxjvwirLk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "32f63574c85fbc80e4ba1fbb932cde9619bad25e",
+        "rev": "1719f27dd95fd4206afb9cec9f415b539978827e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-23.11";
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-24.05";
   };
 
   outputs = { self, nixpkgs, flake-utils, nixpkgs-stable, ... }:
@@ -29,12 +29,10 @@
           checks = {
             defaultPackage = self.packages.${system}.default;
             nixosStablePackage = pkgsStable.nix-prefetch-github;
-            nix-prefetch-github-python39 =
-              pkgs.python39.pkgs.nix-prefetch-github;
-            nix-prefetch-github-python310 =
-              pkgs.python310.pkgs.nix-prefetch-github;
             nix-prefetch-github-python311 =
               pkgs.python311.pkgs.nix-prefetch-github;
+            nix-prefetch-github-python312 =
+              pkgs.python312.pkgs.nix-prefetch-github;
             black-check = pkgs.runCommand "black-nix-prefetch-github" { } ''
               cd ${self}
               ${python.pkgs.black}/bin/black --check .

--- a/nix_prefetch_github/controller/nix_prefetch_github_directory_controller.py
+++ b/nix_prefetch_github/controller/nix_prefetch_github_directory_controller.py
@@ -12,8 +12,7 @@ from nix_prefetch_github.use_cases.prefetch_directory import (
 
 
 class ProcessEnvironment(Protocol):
-    def get_cwd(self) -> str:
-        ...
+    def get_cwd(self) -> str: ...
 
 
 @dataclass
@@ -33,9 +32,9 @@ class PrefetchDirectoryController:
         self.use_case.prefetch_directory(
             request=Request(
                 prefetch_options=args.prefetch_options,
-                directory=args.directory
-                if args.directory
-                else self.environment.get_cwd(),
+                directory=(
+                    args.directory if args.directory else self.environment.get_cwd()
+                ),
                 remote=args.remote,
             )
         )

--- a/nix_prefetch_github/github.py
+++ b/nix_prefetch_github/github.py
@@ -12,8 +12,7 @@ from nix_prefetch_github.interfaces import GithubRepository
 
 
 class Environment(Protocol):
-    def get(self, key: str) -> Optional[str]:
-        ...
+    def get(self, key: str) -> Optional[str]: ...
 
 
 class GithubAPIImpl:

--- a/nix_prefetch_github/interfaces.py
+++ b/nix_prefetch_github/interfaces.py
@@ -9,13 +9,11 @@ from typing import Dict, List, Optional, Protocol, Tuple, Union
 class Alerter(Protocol):
     def alert_user_about_unsafe_prefetch_options(
         self, prefetch_options: PrefetchOptions
-    ) -> None:
-        ...
+    ) -> None: ...
 
 
 class RevisionIndex(Protocol):
-    def get_revision_by_name(self, name: str) -> Optional[str]:
-        ...
+    def get_revision_by_name(self, name: str) -> Optional[str]: ...
 
 
 @dataclass(frozen=True)
@@ -38,8 +36,7 @@ class PrefetchOptions:
 
 
 class HashConverter(Protocol):
-    def convert_sha256_to_sri(self, original: str) -> Optional[str]:
-        ...
+    def convert_sha256_to_sri(self, original: str) -> Optional[str]: ...
 
 
 class UrlHasher(Protocol):
@@ -48,38 +45,33 @@ class UrlHasher(Protocol):
         repository: GithubRepository,
         revision: str,
         prefetch_options: PrefetchOptions,
-    ) -> Optional[str]:
-        ...
+    ) -> Optional[str]: ...
 
 
 class GithubAPI(Protocol):
-    def get_tag_of_latest_release(self, repository: GithubRepository) -> Optional[str]:
-        ...
+    def get_tag_of_latest_release(
+        self, repository: GithubRepository
+    ) -> Optional[str]: ...
 
     def get_commit_date(
         self, repository: GithubRepository, commit_sha1_hash: str
-    ) -> Optional[datetime]:
-        ...
+    ) -> Optional[datetime]: ...
 
 
 class RevisionIndexFactory(Protocol):
     def get_revision_index(
         self, repository: GithubRepository
-    ) -> Optional[RevisionIndex]:
-        ...
+    ) -> Optional[RevisionIndex]: ...
 
 
 class RepositoryDetector(Protocol):
     def detect_github_repository(
         self, directory: str, remote_name: Optional[str]
-    ) -> Optional[GithubRepository]:
-        ...
+    ) -> Optional[GithubRepository]: ...
 
-    def is_repository_dirty(self, directory: str) -> bool:
-        ...
+    def is_repository_dirty(self, directory: str) -> bool: ...
 
-    def get_current_revision(self, directory: str) -> Optional[str]:
-        ...
+    def get_current_revision(self, directory: str) -> Optional[str]: ...
 
 
 @dataclass(frozen=True)
@@ -114,8 +106,7 @@ class Prefetcher(Protocol):
         repository: GithubRepository,
         rev: Optional[str],
         prefetch_options: PrefetchOptions,
-    ) -> PrefetchResult:
-        ...
+    ) -> PrefetchResult: ...
 
 
 class CommandRunner(Protocol):
@@ -125,23 +116,19 @@ class CommandRunner(Protocol):
         cwd: Optional[str] = None,
         environment_variables: Optional[Dict[str, str]] = None,
         merge_stderr: bool = False,
-    ) -> Tuple[int, str]:
-        ...
+    ) -> Tuple[int, str]: ...
 
 
 class CommandAvailabilityChecker(Protocol):
-    def is_command_available(self, command: str) -> bool:
-        ...
+    def is_command_available(self, command: str) -> bool: ...
 
 
 class RepositoryRenderer(Protocol):
-    def render_prefetched_repository(self, repository: PrefetchedRepository) -> str:
-        ...
+    def render_prefetched_repository(self, repository: PrefetchedRepository) -> str: ...
 
 
 class Presenter(Protocol):
-    def present(self, prefetch_result: PrefetchResult) -> None:
-        ...
+    def present(self, prefetch_result: PrefetchResult) -> None: ...
 
 
 @enum.unique
@@ -152,8 +139,7 @@ class RenderingFormat(enum.Enum):
 
 
 class RenderingFormatSelector(Protocol):
-    def set_rendering_format(self, rendering_format: RenderingFormat) -> None:
-        ...
+    def set_rendering_format(self, rendering_format: RenderingFormat) -> None: ...
 
 
 @dataclass
@@ -164,5 +150,4 @@ class ViewModel:
 
 
 class CommandLineView(Protocol):
-    def render_view_model(self, model: ViewModel) -> None:
-        ...
+    def render_view_model(self, model: ViewModel) -> None: ...

--- a/nix_prefetch_github/logging.py
+++ b/nix_prefetch_github/logging.py
@@ -39,8 +39,9 @@ class LoggingConfiguration:
 
 
 class LoggerManager(Protocol):
-    def set_logging_configuration(self, configuration: LoggingConfiguration) -> None:
-        ...
+    def set_logging_configuration(
+        self, configuration: LoggingConfiguration
+    ) -> None: ...
 
 
 class LoggerFactoryImpl:

--- a/nix_prefetch_github/use_cases/prefetch_directory.py
+++ b/nix_prefetch_github/use_cases/prefetch_directory.py
@@ -13,8 +13,7 @@ from nix_prefetch_github.interfaces import (
 
 
 class PrefetchDirectoryUseCase(Protocol):
-    def prefetch_directory(self, request: Request) -> None:
-        ...
+    def prefetch_directory(self, request: Request) -> None: ...
 
 
 @dataclass

--- a/nix_prefetch_github/use_cases/prefetch_github_repository.py
+++ b/nix_prefetch_github/use_cases/prefetch_github_repository.py
@@ -13,8 +13,7 @@ from nix_prefetch_github.interfaces import (
 
 
 class PrefetchGithubRepositoryUseCase(Protocol):
-    def prefetch_github_repository(self, request: Request) -> None:
-        ...
+    def prefetch_github_repository(self, request: Request) -> None: ...
 
 
 @dataclass

--- a/nix_prefetch_github/use_cases/prefetch_latest_release.py
+++ b/nix_prefetch_github/use_cases/prefetch_latest_release.py
@@ -13,8 +13,7 @@ from nix_prefetch_github.interfaces import (
 
 
 class PrefetchLatestReleaseUseCase(Protocol):
-    def prefetch_latest_release(self, request: Request) -> None:
-        ...
+    def prefetch_latest_release(self, request: Request) -> None: ...
 
 
 @dataclass

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,15 +8,15 @@ version = file: nix_prefetch_github/VERSION
 url = https://github.com/seppeljordan/nix-prefetch-github
 
 [options]
-python_requires = >= 3.9
+python_requires = >= 3.11
 classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Topic :: Software Development :: Version Control :: Git
     Topic :: System :: Software Distribution
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 package_dir =
     nix_prefetch_github = nix_prefetch_github
 packages = find:
@@ -37,7 +37,7 @@ files = .,test-pypi-install
 ignore_missing_imports = True
 
 [flake8]
-ignore = E501, W503
+ignore = E501, W503, E704, E226
 exclude =
     .mypy_cache
     site-packages


### PR DESCRIPTION
Use NixOS 24.05 as stable nixpkgs. Also drop support for Python <3.11.